### PR TITLE
新增 Cloudflare Web Analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,8 @@ PUBLIC_GISCUS_REPO=your-handle/your-repo
 PUBLIC_GISCUS_REPO_ID=R_xxxxxxxxxxx
 PUBLIC_GISCUS_CATEGORY=Announcements
 PUBLIC_GISCUS_CATEGORY_ID=DIC_xxxxxxxxxxx
+
+# --- Cloudflare Web Analytics ---
+# Token from https://dash.cloudflare.com/?to=/:account/web-analytics
+# Leave blank to disable. Only loads in production builds.
+PUBLIC_CF_ANALYTICS_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ npm run format:check # Prettier check
 | `PUBLIC_GISCUS_REPO_ID` | 開啟留言時 | giscus.app 產生 |
 | `PUBLIC_GISCUS_CATEGORY` | 開啟留言時 | giscus.app 產生 |
 | `PUBLIC_GISCUS_CATEGORY_ID` | 開啟留言時 | giscus.app 產生 |
+| `PUBLIC_CF_ANALYTICS_TOKEN` | no | Cloudflare Web Analytics token；留白關閉，僅 production build 注入 beacon |
 
 CI / GitHub Actions：以上環境變數設在 repo 的 `Settings → Environments → github-pages → Environment variables`。
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -120,6 +120,15 @@ const meta: SeoMeta =
         document.addEventListener('astro:after-swap', applyTheme);
       })();
     </script>
+    {
+      import.meta.env.PROD && import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN && (
+        <script
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon={`{"token": "${import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN}"}`}
+        />
+      )
+    }
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- 在 `BaseLayout` 注入 Cloudflare Web Analytics beacon，僅 production build 且設定 `PUBLIC_CF_ANALYTICS_TOKEN` 時載入
- 新增 `.env.example` 範本與 `CLAUDE.md` 環境變數說明

## Test plan
- [ ] `.env` 補 token 後 `npm run build && npm run preview`，確認 `<head>` 有 `cloudflareinsights.com/beacon.min.js`
- [ ] `npm run dev` 確認 dev mode 不會載入 beacon
- [ ] Deploy 後到 Cloudflare Web Analytics dashboard 確認有收到 page views

🤖 Generated with [Claude Code](https://claude.com/claude-code)